### PR TITLE
fix broken index tree in chrome dev

### DIFF
--- a/assets/style/components/navigation/index.less
+++ b/assets/style/components/navigation/index.less
@@ -6,6 +6,7 @@
 		z-index: 1;
 		top: 60px;
 		bottom: 0;
+		left: 0;
 		margin-bottom: 40px;
 		overflow-x: hidden;
 		overflow-y: auto;


### PR DESCRIPTION
The index tree is shifted to the right in chrome dev. (looks nice in firefox nightly)
Fixed that, but did not test on more browsers than Chrome 52.0.2739.0 dev (64-bit) and FF 49.0a1 (2016-05-03).

![screenshot from 2016-05-24 11-00-01](https://cloud.githubusercontent.com/assets/5762777/15498983/27fd9bc0-21a2-11e6-895d-4896b607866b.png)
