### PR TITLE
fix(shorcuts): Added alt key as modifier

### DIFF
--- a/source/application/components/content/shortcuts.js
+++ b/source/application/components/content/shortcuts.js
@@ -10,22 +10,22 @@ const source = `
 \`patternplate-client\` provides a number of keyboard shortcuts for your convenience.
 Most links reveal attached keyboard shortcuts when hovered, complementing the table below.
 
-| Combination     | Scope      | Effect                                         |
-|:---------------:|:----------:|:-----------------------------------------------|
-|\`Ctrl+k\`       | Global     | Show this reference                            |
-|\`Ctrl+c\`       | Global     | Toggle the debug console                       |
-|\`Ctrl+d\`       | Global     | Open the documentation                         |
-|\`Ctrl+e\`       | Global     | Toggle expansion of the sidebar                |
-|\`Ctrl+enter\`   | Console    | Apply changes to application state             |
-|\`Ctrl+f\`       | Pattern    | Open current pattern in new tab                |
-|\`Ctrl+h\`       | Global     | Toggle visibility of hidden patterns           |
-|\`Ctrl+i\`       | Global     | Toggle issue reportng helper                   |
-|\`Ctrl+l\`       | Pattern    | Toggle pattern rulers                          |
-|\`Ctrl+o\`       | Global     | Show/hide opacity indicators                   |
-|\`Ctrl+r\`       | Pattern    | Reload the current pattern                     |
-|\`Ctrl+space\`   | Global     | Toggle search focus                            |
-|\`Ctrl+t\`       | Global     | Toggle active theme                            |
-|\`Esc\`          | Global     | Close everything that could be considered open |
+| Combination         | Scope      | Effect                                         |
+|:-------------------:|:----------:|:-----------------------------------------------|
+|\`Ctrl+Alt+k\`       | Global     | Show this reference                            |
+|\`Ctrl+Alt+c\`       | Global     | Toggle the debug console                       |
+|\`Ctrl+Alt+d\`       | Global     | Open the documentation                         |
+|\`Ctrl+Alt+e\`       | Global     | Toggle expansion of the sidebar                |
+|\`Ctrl+Alt+enter\`   | Console    | Apply changes to application state             |
+|\`Ctrl+Alt+f\`       | Pattern    | Open current pattern in new tab                |
+|\`Ctrl+Alt+h\`       | Global     | Toggle visibility of hidden patterns           |
+|\`Ctrl+Alt+i\`       | Global     | Toggle issue reportng helper                   |
+|\`Ctrl+Alt+l\`       | Pattern    | Toggle pattern rulers                          |
+|\`Ctrl+Alt+o\`       | Global     | Show/hide opacity indicators                   |
+|\`Ctrl+Alt+r\`       | Pattern    | Reload the current pattern                     |
+|\`Ctrl+Alt+space\`   | Global     | Toggle search focus                            |
+|\`Ctrl+Alt+t\`       | Global     | Toggle active theme                            |
+|\`Esc\`              | Global     | Close everything that could be considered open |
 `;
 
 export default ShortcutsLightbox;

--- a/source/application/components/content/shortcuts.md
+++ b/source/application/components/content/shortcuts.md
@@ -1,5 +1,0 @@
-> Better living through keyboard controls.
-
-| Combination | Effect |
-|:---------------:|:-------|
-|||

--- a/source/assets/script/index.js
+++ b/source/assets/script/index.js
@@ -27,54 +27,55 @@ function bind(app) {
 	const {store: {dispatch}} = app;
 
 	global.addEventListener('keydown', e => {
-		const ctrl = e.ctrlKey;
+		// Using ctrl + alt here due to OS differnces (e.g. ctrl + c)
+		const modifier = e.ctrlKey && e.altKey;
 		const code = e.data ? e.data.keyCode : e.keyCode;
 
-		if (ctrl && code === 67) { // ctrl+c
+		if (modifier && code === 67) { // ctrl+alt+c
 			dispatch(actions.toggleConsole());
 		}
 
-		if (ctrl && code === 68) { // ctrl+d
+		if (modifier && code === 68) { // ctrl+alt+d
 			dispatch(actions.openDocumentation());
 		}
 
-		if (ctrl && code === 69) { // ctrl+e
+		if (modifier && code === 69) { // ctrl+alt+e
 			dispatch(actions.toggleExpandMenu());
 		}
 
-		if (ctrl && code === 70) { // ctrl+f
+		if (modifier && code === 70) { // ctrl+alt+f
 			dispatch(actions.openFullscreen());
 		}
 
-		if (ctrl && code === 72) { // ctrl+h
+		if (modifier && code === 72) { // ctrl+alt+h
 			dispatch(actions.toggleHide());
 		}
 
-		if (ctrl && code === 73) { // ctrl+i
+		if (modifier && code === 73) { // ctrl+alt+i
 			dispatch(actions.toggleIssue());
 		}
 
-		if (ctrl && code === 79) { // ctrl+o
+		if (modifier && code === 79) { // ctrl+alt+o
 			dispatch(actions.toggleOpacity());
 		}
 
-		if (ctrl && code === 75) { // ctrl+k
+		if (modifier && code === 75) { // ctrl+alt+k
 			dispatch(actions.toggleKeyboardShortcuts());
 		}
 
-		if (ctrl && code === 76) { // ctrl+l
+		if (modifier && code === 76) { // ctrl+alt+l
 			dispatch(actions.toggleRulers());
 		}
 
-		if (ctrl && code === 82) { // ctrl+r
+		if (modifier && code === 82) { // ctrl+alt+r
 			dispatch(actions.loadPattern());
 		}
 
-		if (ctrl && code === 32) { // ctrl+space
+		if (modifier && code === 32) { // ctrl+alt+space
 			dispatch(actions.toggleSearchFocus());
 		}
 
-		if (ctrl && code === 84) { // ctrl+t
+		if (modifier && code === 84) { // ctrl+alt+t
 			dispatch(actions.toggleTheme());
 		}
 


### PR DESCRIPTION
This fixes sinnerschrader/patternplate#118 by adding `altKey` to existing `ctrlKey` as modifier for keyboard shortcuts.