### PR TITLE
fix(components/select): replaced transparent text color by opacity

### DIFF
--- a/source/assets/style/components/select/index.less
+++ b/source/assets/style/components/select/index.less
@@ -15,8 +15,7 @@
 		border: 0;
 		border-radius: none;
 		appearance: none;
-		background: none;
-		color: transparent;
+		opacity: 0;
 		&:focus {
 			outline: none;
 		}


### PR DESCRIPTION
Fixed sinnerschrader/patternplate#117 by setting opacity instead of transparent text color.